### PR TITLE
fix: 削除モードボタンをタイムライン設定へ移設

### DIFF
--- a/components/CharacterColumn.tsx
+++ b/components/CharacterColumn.tsx
@@ -18,8 +18,6 @@ interface CharacterColumnProps {
   onCharacterSelect: (character: Operator | null, index: number) => void
   onCharacterReorder: (fromIndex: number, toIndex: number) => void
   deleteMode: boolean
-  onToggleDeleteMode: () => void
-  deleteModeLabel: string
 }
 
 function CharacterSlotItem({
@@ -101,8 +99,6 @@ export default function CharacterColumn({
   onCharacterSelect,
   onCharacterReorder,
   deleteMode,
-  onToggleDeleteMode,
-  deleteModeLabel,
 }: CharacterColumnProps) {
   const t = useTranslations()
   const [isSelectorOpen, setIsSelectorOpen] = useState(false)
@@ -174,15 +170,6 @@ export default function CharacterColumn({
           <DndContext collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
             <SortableContext items={characters.map((_, i) => `slot-${i}`)} strategy={verticalListSortingStrategy}>
               <div className="space-y-2">
-                <Button
-                  type="button"
-                  variant={deleteMode ? 'destructive' : 'outline'}
-                  size="sm"
-                  onClick={onToggleDeleteMode}
-                  className="w-full"
-                >
-                  {deleteModeLabel}
-                </Button>
                 {characters.map((character, index) => (
                   <CharacterSlotItem
                     key={`slot-${index}`}
@@ -199,15 +186,6 @@ export default function CharacterColumn({
         </div>
       ) : (
         <div className="w-56 shrink-0 space-y-2">
-          <Button
-            type="button"
-            variant={deleteMode ? 'destructive' : 'outline'}
-            size="sm"
-            onClick={onToggleDeleteMode}
-            className="w-full"
-          >
-            {deleteModeLabel}
-          </Button>
           <div className="space-y-2">
             {characters.map((character, index) => (
               <div key={`slot-${index}`} className="px-3 py-2 bg-gray-700 rounded">

--- a/components/ComboBuilder.tsx
+++ b/components/ComboBuilder.tsx
@@ -17,6 +17,7 @@ import { SpTimelineChart } from '@/components/SpTimelineChart'
 import { TimelineScale } from '@/components/TimelineScale'
 import ControlPanel from '@/components/ControlPanel'
 import LoadDialog from '@/components/LoadDialog'
+import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { useComboActions } from '@/hooks/useComboActions'
 import { useComboCharacters } from '@/hooks/useComboCharacters'
@@ -230,6 +231,15 @@ export const ComboBuilder = () => {
       <div className="bg-gray-800 p-4 rounded-lg mb-4">
         <div className="text-sm font-medium text-gray-200 mb-3">{t('timeline.settingsTitle')}</div>
         <div className="flex flex-wrap items-end gap-3">
+          <Button
+            type="button"
+            variant={deleteMode ? 'destructive' : 'outline'}
+            size="sm"
+            onClick={() => setDeleteMode((prev) => !prev)}
+            className="h-10"
+          >
+            {deleteMode ? t('actions.deleteModeOn') : t('actions.deleteModeOff')}
+          </Button>
           <div className="flex flex-col gap-2 w-[190px]">
             <label className="text-xs text-gray-300" htmlFor="timeline-duration">
               {t('timeline.durationLabel')}
@@ -390,8 +400,6 @@ export const ComboBuilder = () => {
               onCharacterSelect={handleCharacterSelect}
               onCharacterReorder={handleCharacterReorder}
               deleteMode={deleteMode}
-              onToggleDeleteMode={() => setDeleteMode((prev) => !prev)}
-              deleteModeLabel={deleteMode ? t('actions.deleteModeOn') : t('actions.deleteModeOff')}
             />
             <TimelineColumn
               characters={characters}


### PR DESCRIPTION
## 概要
- Issue #11 に対応し、`削除モード` ボタンをキャラクター列からタイムライン設定へ移設しました。

## 変更内容
- `components/CharacterColumn.tsx`
  - 削除モードボタンの描画を削除
  - 不要になった props（`onToggleDeleteMode`, `deleteModeLabel`）を削除
- `components/ComboBuilder.tsx`
  - 「タイムライン設定」エリア先頭に削除モードボタンを追加
  - 既存の `deleteMode` state に接続し、ON/OFF ラベル表示を維持

## 確認
- `tests/e2e/combo-builder.spec.ts` の `should display the main page correctly` が通過
- `tests/e2e/plunge-attack.spec.ts` の `落下攻撃アクションを削除モードで削除できる` が通過

Closes #11
