### PR TITLE
fix: 共有タイムライン長さに秒数設定を反映

### DIFF
--- a/components/ShareableTimeline.tsx
+++ b/components/ShareableTimeline.tsx
@@ -5,8 +5,7 @@ import { useTranslations } from 'next-intl'
 import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 
 import { getOperatorIdByName, OPERATORS } from '@/lib/data/operators'
-import { getStatusEffectForAction } from '@/lib/data/skills'
-import { TIMELINE_WIDTH, getSecondMarkerWidthPx } from '@/lib/timeline'
+import { TIMELINE_DURATION, TIMELINE_WIDTH } from '@/lib/timeline'
 
 import { SkillType } from '@/types/combo'
 import type { ComboAction, Operator } from '@/types/combo'
@@ -14,7 +13,6 @@ import type { ComboAction, Operator } from '@/types/combo'
 import {
   SKILL_TYPE_LABELS,
   SKILL_TYPE_BG_COLORS,
-  SKILL_TYPE_TEXT_COLORS,
   SKILL_TYPE_ACCENT_COLORS,
 } from '@/components/combo-timeline/skillTypeConfig'
 
@@ -32,7 +30,8 @@ export default function ShareableTimeline({
   timelineDurationMs,
 }: ShareableTimelineProps) {
   const t = useTranslations()
-  const secondMarkerWidthPx = getSecondMarkerWidthPx(timelineDurationMs)
+  const shareableTimelineWidthPx = (timelineDurationMs / TIMELINE_DURATION) * TIMELINE_WIDTH
+  const secondMarkerWidthPx = shareableTimelineWidthPx / (timelineDurationMs / 1000)
 
   const getActionPosition = (timing: number) => {
     return (timing / timelineDurationMs) * TIMELINE_WIDTH
@@ -78,56 +77,59 @@ export default function ShareableTimeline({
               </div>
 
               {/* Timeline content - single unified timeline */}
-              <div
-                className="relative bg-gray-700 rounded flex-1"
-                style={{ height: TIMELINE_ROW_HEIGHT_PX, width: `${TIMELINE_WIDTH}px` }}
-                data-timeline-line
-              >
-                {/* Grid background */}
+              <div className="min-w-0 flex-1 overflow-x-auto">
                 <div
-                  className="absolute inset-0 pointer-events-none z-10 rounded"
-                  style={{
-                    backgroundImage: 'linear-gradient(to right, rgba(255, 255, 255, 0.2) 1px, transparent 1px)',
-                    backgroundSize: `${secondMarkerWidthPx}px 100%`,
-                  }}
-                />
+                  className="relative bg-gray-700 rounded shrink-0"
+                  style={{ height: TIMELINE_ROW_HEIGHT_PX, width: `${shareableTimelineWidthPx}px` }}
+                  data-timeline-line
+                  data-testid="shareable-timeline-line"
+                >
+                  {/* Grid background */}
+                  <div
+                    className="absolute inset-0 pointer-events-none z-10 rounded"
+                    style={{
+                      backgroundImage: 'linear-gradient(to right, rgba(255, 255, 255, 0.2) 1px, transparent 1px)',
+                      backgroundSize: `${secondMarkerWidthPx}px 100%`,
+                    }}
+                  />
 
-                {/* Action markers for all skill types */}
-                {actions
-                  .filter((a) => character && a.characterId === character.name)
-                  .sort((a, b) => a.timing - b.timing)
-                  .map((action) => {
-                    const left = getActionPosition(action.timing)
-                    const skillLabel = SKILL_TYPE_LABELS[action.type] || ''
+                  {/* Action markers for all skill types */}
+                  {actions
+                    .filter((a) => character && a.characterId === character.name)
+                    .sort((a, b) => a.timing - b.timing)
+                    .map((action) => {
+                      const left = getActionPosition(action.timing)
+                      const skillLabel = SKILL_TYPE_LABELS[action.type] || ''
 
-                    return (
-                      <TooltipProvider key={action.id} delayDuration={300}>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <div
-                              className={`absolute top-1 z-20 h-7 ${SKILL_TYPE_BG_COLORS[action.type]} rounded px-2 text-xs flex items-center justify-center pointer-events-none overflow-hidden border-l-2 font-medium`}
-                              style={{
-                                left: `${left}px`,
-                                width: '50px',
-                                borderLeftColor: SKILL_TYPE_ACCENT_COLORS[action.type],
-                              }}
-                              title={skillLabel}
-                            >
-                              <span className="truncate text-xs">{skillLabel}</span>
-                            </div>
-                          </TooltipTrigger>
-                          {operatorKey && (
-                            <TooltipContent side="top" className="max-w-xs">
-                              {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-                              <p className="font-semibold text-sm">{t(`character.${operatorKey}.${getSkillI18nSection(action.type)}.name` as any)}</p>
-                              {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-                              <p className="text-xs mt-1">{t(`character.${operatorKey}.${getSkillI18nSection(action.type)}.description` as any)}</p>
-                            </TooltipContent>
-                          )}
-                        </Tooltip>
-                      </TooltipProvider>
-                    )
-                  })}
+                      return (
+                        <TooltipProvider key={action.id} delayDuration={300}>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <div
+                                className={`absolute top-1 z-20 h-7 ${SKILL_TYPE_BG_COLORS[action.type]} rounded px-2 text-xs flex items-center justify-center pointer-events-none overflow-hidden border-l-2 font-medium`}
+                                style={{
+                                  left: `${left}px`,
+                                  width: '50px',
+                                  borderLeftColor: SKILL_TYPE_ACCENT_COLORS[action.type],
+                                }}
+                                title={skillLabel}
+                              >
+                                <span className="truncate text-xs">{skillLabel}</span>
+                              </div>
+                            </TooltipTrigger>
+                            {operatorKey && (
+                              <TooltipContent side="top" className="max-w-xs">
+                                {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+                                <p className="font-semibold text-sm">{t(`character.${operatorKey}.${getSkillI18nSection(action.type)}.name` as any)}</p>
+                                {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+                                <p className="text-xs mt-1">{t(`character.${operatorKey}.${getSkillI18nSection(action.type)}.description` as any)}</p>
+                              </TooltipContent>
+                            )}
+                          </Tooltip>
+                        </TooltipProvider>
+                      )
+                    })}
+                </div>
               </div>
             </div>
           )

--- a/tests/e2e/url-sharing.spec.ts
+++ b/tests/e2e/url-sharing.spec.ts
@@ -29,6 +29,7 @@ test.describe('URL 共有機能', () => {
     await builder.setComboName('URL 復元テスト')
     await builder.selectCharacter(0, 'レーヴァテイン')
     await builder.selectCharacter(1, 'ギルベルタ')
+    await page.locator('#timeline-duration').fill('60')
 
     await builder.shareButton.click()
     const sharedUrl = await page.evaluate(() => navigator.clipboard.readText())
@@ -78,6 +79,8 @@ test.describe('URL 共有機能', () => {
     
     // Now check the combo name
     await expect(comboNameInput).toHaveValue('URL 復元テスト')
+    await expect(newPage.locator('#timeline-duration')).toHaveValue('60')
+    await expect(restoredBuilder.page.getByTestId('shareable-timeline-line').first()).toHaveCSS('width', '2000px')
 
     await newPage.close()
   })

--- a/tests/unit/components/ShareableTimeline.test.tsx
+++ b/tests/unit/components/ShareableTimeline.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+
+import ShareableTimeline from '@/components/ShareableTimeline'
+
+describe('ShareableTimeline', () => {
+  it('changes timeline width based on timelineDurationMs', () => {
+    const baseProps = {
+      characters: [null, null, null, null],
+      actions: [],
+    }
+
+    const { rerender } = render(<ShareableTimeline {...baseProps} timelineDurationMs={30000} />)
+    const firstLine = screen.getAllByTestId('shareable-timeline-line')[0]
+    expect(firstLine).toHaveStyle({ width: '1000px' })
+
+    rerender(<ShareableTimeline {...baseProps} timelineDurationMs={60000} />)
+    const updatedFirstLine = screen.getAllByTestId('shareable-timeline-line')[0]
+    expect(updatedFirstLine).toHaveStyle({ width: '2000px' })
+  })
+})


### PR DESCRIPTION
## 概要
- 共有タイムラインの幅が常に固定だった問題を修正し、`timelineDurationMs` に応じて可変になるようにしました。
- 30秒では従来どおり 1000px、60秒では 2000px になるように反映されます。

## 変更内容
- `components/ShareableTimeline.tsx`
  - 共有タイムライン幅を `timelineDurationMs` から算出する実装に変更
  - 可変幅が `flex` で潰れないように、横スクロール可能なラッパー構造へ調整
  - テスト用に `data-testid="shareable-timeline-line"` を追加
- `tests/unit/components/ShareableTimeline.test.tsx`
  - 秒数変更（30秒→60秒）で幅が 1000px→2000px に変化することを追加検証
- `tests/e2e/url-sharing.spec.ts`
  - 60秒設定を共有URLで復元し、秒数入力値と共有タイムライン幅の反映を検証

## 確認
- `pnpm vitest run tests/unit/components/ShareableTimeline.test.tsx tests/unit/lib/storage.test.ts`
- `pnpm exec playwright test tests/e2e/url-sharing.spec.ts --workers=1`
- `pnpm lint` は既存の `components/CharacterColumn.tsx` 由来のエラーで失敗（今回差分起因ではありません）

Closes #12
