### PR TITLE
fix: 設定用タイムラインの0秒位置を統一

### DIFF
--- a/components/OperatorStatusTimeline.tsx
+++ b/components/OperatorStatusTimeline.tsx
@@ -5,7 +5,6 @@ import { useTranslations } from 'next-intl'
 
 import {
   TIMELINE_WIDTH,
-  getSecondMarkerWidthPx,
   STATUS_EFFECT_COLORS,
   LONG_STATUS_EFFECT_DURATION_MS,
 } from '@/lib/timeline'
@@ -41,7 +40,7 @@ export const OperatorStatusTimeline = ({
   showHeader = true,
 }: OperatorStatusTimelineProps) => {
   const t = useTranslations()
-  const secondMarkerWidthPx = getSecondMarkerWidthPx(timelineDurationMs)
+  const totalSeconds = Math.round(timelineDurationMs / 1000)
   
   const getActionPosition = (timing: number) => {
     return (timing / timelineDurationMs) * TIMELINE_WIDTH
@@ -150,9 +149,13 @@ export const OperatorStatusTimeline = ({
         <div className="flex items-center">
           <div className="w-40 text-sm font-semibold text-gray-200">自操作キャラ</div>
           <div className="w-24 shrink-0" />
-          <div className="text-xs text-gray-500" style={{ width: `${TIMELINE_WIDTH}px` }}>
-            {Array.from({ length: Math.ceil(timelineDurationMs / 1000) }, (_, i) => (
-              <span key={i} style={{ display: 'inline-block', width: `${secondMarkerWidthPx}px`, textAlign: 'center' }}>
+          <div className="relative h-6 text-xs text-gray-500" style={{ width: `${TIMELINE_WIDTH}px` }}>
+            {Array.from({ length: totalSeconds + 1 }, (_, i) => (
+              <span
+                key={i}
+                className="absolute"
+                style={{ left: `${(i / totalSeconds) * TIMELINE_WIDTH}px` }}
+              >
                 {i}s
               </span>
             ))}

--- a/components/SpTimelineChart.tsx
+++ b/components/SpTimelineChart.tsx
@@ -4,7 +4,11 @@ import { useTranslations } from 'next-intl'
 import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from 'recharts'
 
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from '@/components/ui/chart'
-import { TIMELINE_WIDTH } from '@/lib/timeline'
+import {
+  TIMELINE_CHART_CANVAS_WIDTH,
+  TIMELINE_CHART_RIGHT_MARGIN,
+  TIMELINE_CHART_Y_AXIS_WIDTH,
+} from '@/lib/timeline'
 
 interface SpTimelineChartProps {
   spChartData: { timing: number; sp: number }[]
@@ -30,7 +34,7 @@ export const SpTimelineChart = ({
   const chartContent = (
     <>
       <div className="w-24 shrink-0" />
-      <div className="relative" style={{ width: `${TIMELINE_WIDTH}px`, height: '96px' }}>
+      <div className="relative" style={{ width: `${TIMELINE_CHART_CANVAS_WIDTH}px`, height: '96px' }}>
         <ChartContainer
           id="sp-timeline"
           config={{
@@ -42,7 +46,7 @@ export const SpTimelineChart = ({
           className="w-full aspect-auto rounded bg-gray-700/40"
           style={{ height: '100%' }}
         >
-          <BarChart data={spChartData} margin={{ left: 0, right: 12, top: 8, bottom: 0 }}>
+          <BarChart data={spChartData} margin={{ left: 0, right: TIMELINE_CHART_RIGHT_MARGIN, top: 8, bottom: 0 }}>
             <CartesianGrid vertical={false} strokeDasharray="4 4" stroke="rgba(255, 255, 255, 0.08)" />
             <XAxis
               dataKey="timing"
@@ -55,7 +59,7 @@ export const SpTimelineChart = ({
               tickFormatter={(value) => `${value / 1000}s`}
             />
             <YAxis
-              width={24}
+              width={TIMELINE_CHART_Y_AXIS_WIDTH}
               orientation="right"
               tickLine={false}
               axisLine={false}

--- a/components/SpTimelineChart.tsx
+++ b/components/SpTimelineChart.tsx
@@ -56,6 +56,7 @@ export const SpTimelineChart = ({
             />
             <YAxis
               width={24}
+              orientation="right"
               tickLine={false}
               axisLine={false}
               fontSize={10}

--- a/components/StaggerMeterChart.tsx
+++ b/components/StaggerMeterChart.tsx
@@ -4,7 +4,12 @@ import { useTranslations } from 'next-intl'
 import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from 'recharts'
 
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from '@/components/ui/chart'
-import { MAX_STAGGER_METER, TIMELINE_WIDTH } from '@/lib/timeline'
+import {
+  MAX_STAGGER_METER,
+  TIMELINE_CHART_CANVAS_WIDTH,
+  TIMELINE_CHART_RIGHT_MARGIN,
+  TIMELINE_CHART_Y_AXIS_WIDTH,
+} from '@/lib/timeline'
 
 interface StaggerMeterChartProps {
   chartData: { timing: number; staggerMeter: number }[]
@@ -24,7 +29,7 @@ export const StaggerMeterChart = ({
   const chartContent = (
     <>
       <div className="w-24 shrink-0" />
-      <div className="relative" style={{ width: `${TIMELINE_WIDTH}px`, height: '96px' }}>
+      <div className="relative" style={{ width: `${TIMELINE_CHART_CANVAS_WIDTH}px`, height: '96px' }}>
         <ChartContainer
           id="stagger-meter"
           config={{
@@ -36,7 +41,7 @@ export const StaggerMeterChart = ({
           className="w-full aspect-auto rounded bg-gray-700/40"
           style={{ height: '100%' }}
         >
-          <BarChart data={chartData} margin={{ left: 0, right: 12, top: 8, bottom: 0 }}>
+          <BarChart data={chartData} margin={{ left: 0, right: TIMELINE_CHART_RIGHT_MARGIN, top: 8, bottom: 0 }}>
             <CartesianGrid vertical={false} strokeDasharray="4 4" stroke="rgba(255, 255, 255, 0.08)" />
             <XAxis
               dataKey="timing"
@@ -49,7 +54,7 @@ export const StaggerMeterChart = ({
               tickFormatter={(value) => `${value / 1000}s`}
             />
             <YAxis
-              width={24}
+              width={TIMELINE_CHART_Y_AXIS_WIDTH}
               orientation="right"
               tickLine={false}
               axisLine={false}

--- a/components/StaggerMeterChart.tsx
+++ b/components/StaggerMeterChart.tsx
@@ -50,6 +50,7 @@ export const StaggerMeterChart = ({
             />
             <YAxis
               width={24}
+              orientation="right"
               tickLine={false}
               axisLine={false}
               fontSize={10}

--- a/lib/timeline.ts
+++ b/lib/timeline.ts
@@ -11,6 +11,10 @@ export const CHARGE_SEGMENT_WIDTH = 10
 export const ULTIMATE_CHARGE_COLOR_RGB = '239, 68, 68'
 export const ULTIMATE_CHARGE_OPACITY_MULTIPLIER = 0.3
 export const TIMELINE_ROW_HEIGHT_PX = 160
+export const TIMELINE_CHART_Y_AXIS_WIDTH = 24
+export const TIMELINE_CHART_RIGHT_MARGIN = 12
+export const TIMELINE_CHART_CANVAS_WIDTH =
+  TIMELINE_WIDTH + TIMELINE_CHART_Y_AXIS_WIDTH + TIMELINE_CHART_RIGHT_MARGIN
 export const getSecondMarkerWidthPx = (durationMs: number) => {
   return TIMELINE_WIDTH / (durationMs / 1000)
 }

--- a/tests/unit/components/OperatorStatusTimeline.test.tsx
+++ b/tests/unit/components/OperatorStatusTimeline.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { OperatorStatusTimeline } from '@/components/OperatorStatusTimeline'
+import { Buff, SkillType } from '@/types/combo'
+
+vi.mock('@/lib/data/skills', () => ({
+  getStatusEffectForAction: () => [Buff.SUPPORT_CRYSTAL],
+}))
+
+describe('OperatorStatusTimeline', () => {
+  it('aligns header second markers with timeline origin', () => {
+    render(
+      <OperatorStatusTimeline
+        actions={[
+          {
+            id: 'action-1',
+            characterId: 'character.rossi.name',
+            type: SkillType.BATTLE_SKILL,
+            timing: 0,
+          },
+        ]}
+        timelineDurationMs={3000}
+      />
+    )
+
+    expect(screen.getByText('0s')).toHaveStyle({ left: '0px' })
+    expect(screen.getByText('3s')).toHaveStyle({ left: '1000px' })
+  })
+})


### PR DESCRIPTION
## 概要
- Issue #17（設定用タイムラインにおける0秒地点の位置ずれ）を修正しました。
- SP / 敵スタッガー / 他タイムラインで0秒の横位置が揃うように調整しています。

## 変更内容
- `OperatorStatusTimeline` のヘッダー秒目盛りを絶対配置に変更し、`0s` をタイムライン原点に一致させました。
- `SpTimelineChart` の `YAxis` を右側配置に変更し、プロット開始位置のずれを解消しました。
- `StaggerMeterChart` の `YAxis` を右側配置に変更し、SPチャートと同様に原点を統一しました。
- `tests/unit/components/OperatorStatusTimeline.test.tsx` を追加し、`0s` と終端秒マーカー位置を検証するテストを追加しました。

## 関連Issue
- Closes #17
